### PR TITLE
Fix / update SCM meta-data in POM

### DIFF
--- a/sonatype.sbt
+++ b/sonatype.sbt
@@ -9,9 +9,9 @@ pomExtra in Global := {
     </license>
   </licenses>
   <scm>
-    <connection>scm:git:github.com:trueaccord/lenses.git</connection>
-    <developerConnection>scm:git:git@github.com:trueaccord/lenses.git</developerConnection>
-    <url>github.com/trueaccord/lenses</url>
+    <connection>scm:git:https://github.com/scalapb/Lenses.git</connection>
+    <developerConnection>scm:git:git@github.com:scalapb/Lenses.git</developerConnection>
+    <url>https://github.com/scalapb/Lenses</url>
   </scm>
   <developers>
     <developer>


### PR DESCRIPTION
The "connection" URL was missing the generic "git" username, but it
should be a read-only / anonymous clone URL anyway, so just use the
HTTPS URl GitHub provides for this case. The "developerConnection" URL
is only updated to the new project name on GitHub. Finally, the
browsable "url" is updated and prefix with the HTTPS protocol.